### PR TITLE
Add grunt fatal return if the compile fails

### DIFF
--- a/tasks/air_sdk.js
+++ b/tasks/air_sdk.js
@@ -39,9 +39,10 @@ module.exports = function(grunt) {
     }
     var executed = shell.exec(cmdLineOpts);
     if(executed.code === 0 ){
-      console.log("File successfully created!");
+      grunt.log.writeln("File successfully created!");
     }else{
-      console.log(executed.output);
+      grunt.log.error(executed.output);
+      grunt.fail.fatal("Error during compile");
     }
   });
 };


### PR DESCRIPTION
Hello there,
I want to fix the {{subject}} issue.

Currently if the `air_sdk` fails (when a build error occurs) it won't report it on a standard way with _stderr_ or _exit code_. This makes hard to automatize the distribution of flash binaries with `air_sdk` and [`grunt-release`](https://github.com/geddski/grunt-release)'s _afterBump_ options because it won't stop the deploy process.

This commit will resolve this issue.

Please review it and merge it accordingly!
